### PR TITLE
Fixed hirak/prestissimo composer compability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM php:7.0-alpine
 RUN docker-php-ext-install pdo_mysql
 
-RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer && composer global require hirak/prestissimo --no-plugins --no-scripts
-RUN composer --version
+RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer && \
+		composer self-update 1.10.16 && \
+		composer --version && \
+		composer global require hirak/prestissimo --no-plugins --no-scripts
+
 RUN composer global require hirak/prestissimo
 
 WORKDIR /usr/src/myapp


### PR DESCRIPTION
Hello,

There is a compatibility issue with composer 2 and hirak/prestissimo.

Getting this error while building the docker image:

```
Changed current directory to /root/.composer
                                                                                                                    
  [RuntimeException]                                                                                                      
  No composer.json present in the current directory (./composer.json), this may be the cause of the following exception.  
                                                                                                                                                                         
  [InvalidArgumentException]                                                                                               
  Package hirak/prestissimo has a PHP requirement incompatible with your PHP version, PHP extensions and Composer version  
                                                                                                                           

require [--dev] [--dry-run] [--prefer-source] [--prefer-dist] [--fixed] [--no-suggest] [--no-progress] [--no-update] [--no-install] [--no-scripts] [--update-no-dev] [-w|--update-with-dependencies] [-W|--update-with-all-dependencies] [--with-dependencies] [--with-all-dependencies] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--] [<packages>]...
```

So I added downgrade command to the Dockerfile: `composer self-update 1.10.16`, downgrading the composer to version 1.10.16 so hirak/prestissimo will be able to be installed.

Gal Birkman,
DevOps Engineer.